### PR TITLE
Edited the package.json to include the mocha and benchmark as devDepende...

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "bugs": {
     "url": "https://github.com/knrz/CSV.js/issues"
   },
-  "homepage": "https://github.com/knrz/CSV.js"
+  "homepage": "https://github.com/knrz/CSV.js",
+  "devDependencies": {
+    "benchmark": "~1.0.0",
+    "mocha": "~1.20.1"
+  }
 }


### PR DESCRIPTION
Added the dependencies to the package manifest.

By including these packages as devDependencies, they'll be included during 'npm install' but not during 'npm install --production'.

In the future, you can automatically add the package name and version info to devdependencies by installing the dependencies with:

npm install [dependency] --save-dev.

To add add production dependencies you can use:

npm install [dependency] --save
