### PR TITLE
Added script aliases for test.js and benchmark.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.1.3",
   "description": "Simple CSV parsing and encoding. Full RFC 4180 compliance.",
   "main": "csv.js",
-  "scripts": {},
+  "scripts": {
+    "test": "mocha test.js",
+    "benchmark": "node benchmark.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/knrz/CSV.js"


### PR DESCRIPTION
With the script alias...

The test runner can be run by simply calling

```
npm test
```

and the benchmark script can be called with

```
npm run-script benchmark
```

In the future, the tests can be broken into multiple files and run with 'npm run-script [test_name]' and the 'npm test' alias can be modified to run a full suite of tests at once as [demonstrated here](http://stackoverflow.com/a/20384739/290340).
