### PR TITLE
handle null values in array of objects

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -72,6 +72,7 @@
         complete = this.options.done,
 
         stringify = function(value) {
+          if (!value) return null;
           return FLOAT.test(value) ? value : '"' + value.replace(/\"/g, '""') + '"';
         },
 


### PR DESCRIPTION
When encoding:

If an array of objects has null values like key2 in {key1: 'asdf', key2: null, key3: 123} the stringify() function dies trying to regex replace on null.
