### PR TITLE
Test for string instead of float in encode

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -73,7 +73,7 @@
 
         stringify = function(value) {
           if (!value) return null;
-          return FLOAT.test(value) ? value : '"' + value.replace(/\"/g, '""') + '"';
+          return (typeof value !== 'string') ? value : '"' + value.replace(/\"/g, '""') + '"';
         },
 
         sendLine = stream ? function(line) {


### PR DESCRIPTION
Only call the replace method on variables that would have it (strings). Otherwise booleans (true, false) throw an error during encoding.
