### PR TITLE
Add custom cast for parse and encode

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/knrz/CSV.js",
   "devDependencies": {
     "benchmark": "~1.0.0",
+    "deep-equal": "~1.0.0",
     "mocha": "~1.20.1"
   }
 }


### PR DESCRIPTION
I extended cast option to accept Function.
For example, original 'String' cast converts null to "null" in encoding. If we need to change this behavior, we can use custom cast. If we want to convert null to empty string, we can write as below.
```
var customString = function(val) { return val === null ? '' : this.string(val); };
var data = [["123", null], [null, "456"]];
new CSV(data, {cast: ['String', customString]}).encode();
/*
Returns:
"123",\r\n\
"null","456"
*/
```